### PR TITLE
[NewsPublish] Allow for message without commands.

### DIFF
--- a/newspublish/core.py
+++ b/newspublish/core.py
@@ -115,7 +115,7 @@ class NewsPublish(BASECOG):
         await ctx.send("Done. Set alert channel to {}".format(channel.mention))
 
     @commands.Cog.listener()
-    async def on_message(self, message):
+    async def on_message_without_command(self, message):
         """
         Listens for news
         """


### PR DESCRIPTION
This allows people to post commands in the announcement channel without the bot auto-publishing the command along with the message from the bot.

Closes. https://github.com/SharkyTheKing/Sharky/issues/66

Sorry for the delay.