### PR TITLE
[Info Update] Proper guild link for support

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Support
-    url: https://discord.gg/SKEtjnA
-    about: For questions on how to use my cogs
+  - name: Cog Support Server
+    url: https://discord.gg/GET4DVk
+    about: Check \#support_othercogs and you can find me there for further help / questions!


### PR DESCRIPTION
* Changed linked discord to prevent people joining my server and to join red's cog support.