### PR TITLE
[MailSystem] Fix Mailset List

### DIFF
--- a/mailsystem/embedmodel.py
+++ b/mailsystem/embedmodel.py
@@ -122,7 +122,8 @@ class EmbedSettings:
         embed.add_field(
             name="Logging Channel",
             value=self.bot.get_channel(config_info["mail_log_channel"]).mention
-            or "No logging category set",
+            if config_info["mail_log_channel"]
+            else "No logging category set",
             inline=False,
         )
 

--- a/mailsystem/modmail.py
+++ b/mailsystem/modmail.py
@@ -43,7 +43,7 @@ class MailSystem(*mixinargs, metaclass=MetaClass):
     **This is currently in testing. Please review the warning message.** `[p]mailset warn`
     """
 
-    __version__ = "0.0.5"
+    __version__ = "0.0.6"
     __author__ = ["SharkyTheKing", "Kreusada"]
 
     def __init__(self, bot):


### PR DESCRIPTION
Fixes the error when there wasn't a logging channel added when the user uses `[p]mailset list`

Updated version as well.