### PR TITLE
[MailSystem] Remove enforced category

### DIFF
--- a/mailsystem/modmail.py
+++ b/mailsystem/modmail.py
@@ -43,7 +43,7 @@ class MailSystem(*mixinargs, metaclass=MetaClass):
     **This is currently in testing. Please review the warning message.** `[p]mailset warn`
     """
 
-    __version__ = "0.0.6"
+    __version__ = "0.0.7"
     __author__ = ["SharkyTheKing", "Kreusada"]
 
     def __init__(self, bot):

--- a/mailsystem/settings.py
+++ b/mailsystem/settings.py
@@ -53,10 +53,6 @@ class MailSettings(MailSystemMixin):
             await self.config.guild(ctx.guild).mail_log_channel.set(None)
             return await ctx.send("Will no longer log channel deletions/creations.")
 
-        #  May not make it require same category, we'll see.
-        if channel.category.id != await self.config.guild(ctx.guild).category():
-            return await ctx.send("You must put the logging channel in the MailSystem Category.")
-
         await self.config.guild(ctx.guild).mail_log_channel.set(channel.id)
         await ctx.send("Will now log channel deletions/creations to {}".format(channel.mention))
 


### PR DESCRIPTION
Allows users to set the logging channel to whatever channel they want, despite not being in the category set for mailsystem.

Also fixes issues if there was no category set.