### PR TITLE
[MailSystem] Wipe config on ignore

### DIFF
--- a/mailsystem/modmail.py
+++ b/mailsystem/modmail.py
@@ -46,7 +46,7 @@ class MailSystem(*mixinargs, metaclass=MetaClass):
     **This is currently in testing. Please review the warning message.** `[p]mailset warn`
     """
 
-    __version__ = "0.1.1"
+    __version__ = "0.1.2"
     __author__ = ["SharkyTheKing", "Kreusada"]
 
     def __init__(self, bot):


### PR DESCRIPTION
This can only happen if the guild that's ignoring the user(s)' channels are tied to the server.


Example: User A has a modmail channel active in "Modmail Server 1", while the ignore command is being given in "Modmail server 2". THis will not wipe the config, as it's not the same server.

