### PR TITLE
[MailSystem] Split reply into Reply and Anonymous Reply

### DIFF
--- a/mailsystem/modmail.py
+++ b/mailsystem/modmail.py
@@ -46,7 +46,7 @@ class MailSystem(*mixinargs, metaclass=MetaClass):
     **This is currently in testing. Please review the warning message.** `[p]mailset warn`
     """
 
-    __version__ = "0.1.3"
+    __version__ = "0.1.4"
     __author__ = ["SharkyTheKing", "Kreusada"]
 
     def __init__(self, bot):


### PR DESCRIPTION
Due to some issues I've seen while testing in other servers, it's incredibly easy to accidentally trigger an anonymous reply when you just want to do a regular reply.

I still need to test this before I merge.